### PR TITLE
fix: Resolve build failures from previous commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && \
     apt-get install -y \
         gcc \
         pkg-config \
-        upx \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy go.mod and go.sum first for better caching
@@ -24,8 +23,7 @@ COPY . .
 # Build the binary with optimizations
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
     go build -v -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
-    -o infoscope ./cmd/infoscope && \
-    upx --best --lzma infoscope
+    -o infoscope ./cmd/infoscope
 
 # Final stage
 FROM gcr.io/distroless/base-debian12

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 	"unicode"

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -97,7 +97,7 @@ func (db *DB) GetSettingInt(ctx context.Context, key string) (int, error) {
 
 // UpdateSetting updates a setting with optimistic locking
 func (db *DB) UpdateSetting(ctx context.Context, key, value, valueType string) error {
-	result, err := db.ExecContext(ctx,
+	_, err := db.ExecContext(ctx,
 		`INSERT INTO settings (key, value, type, updated_at)
 		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(key) DO UPDATE SET


### PR DESCRIPTION
This commit addresses Go compilation errors and potential Docker build issues that caused the CI runs to fail:

- Corrected an "unused variable" error in `internal/database/queries.go` within the UpdateSetting function.
- Removed an unused "regexp" import from `internal/auth/service.go`.
- Removed `upx` compression from the Dockerfile build process. While the primary build failures were Go compilation errors, `upx` is proactively removed to ensure it doesn't cause further issues with the CGO-enabled binary in the Docker build. This may result in a larger binary but prioritizes build stability.

These changes should allow the build actions to complete successfully.