### PR TITLE
Addressed the Docker build error related to `mkdir` in the distr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,6 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /build/infoscope /app/infoscope
 
-# Create necessary directories
-RUN mkdir -p /app/data /app/web
-
 # Set default environment variables
 ENV INFOSCOPE_PORT=8080 \
     INFOSCOPE_DB_PATH=/app/data/infoscope.db \


### PR DESCRIPTION
…oless image.

I removed the `RUN mkdir -p /app/data /app/web` command from the final stage in the Dockerfile.

This command was causing build failures because the `gcr.io/distroless/base-debian12` image does not include a shell (`/bin/sh`). Since the directories `/app/data` and `/app/web` are declared as `VOLUME`s, Docker will automatically create them when the container starts if they don't already exist.