### PR TITLE
Fix readonly database error in Docker by setting volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update && \
 COPY go.mod go.sum ./
 RUN go mod download
 
+RUN mkdir -p /build/app_final/data /build/app_final/web && \
+    chown -R 65532:65532 /build/app_final
+
 # Copy source code
 COPY . .
 
@@ -34,6 +37,9 @@ WORKDIR /app
 
 # Copy binary from builder
 COPY --from=builder /build/infoscope /app/infoscope
+
+COPY --from=builder --chown=65532:65532 /build/app_final/data /app/data
+COPY --from=builder --chown=65532:65532 /build/app_final/web /app/web
 
 # Set default environment variables
 ENV INFOSCOPE_PORT=8080 \


### PR DESCRIPTION
I modified the Dockerfile to address the "attempt to write a readonly database" error when running as a non-root user.

- In the builder stage, I created /app/data and /app/web directories and set their ownership to 65532:65532 (the non-root UID/GID used in the final stage).
- In the final distroless stage, I copied these pre-owned directories from the builder stage.

This ensures that the application, running as user 65532, has the necessary write permissions to the /app/data and /app/web volumes from its inception, allowing it to create and write to the database file.