### PR TITLE
Fix: Resolve blank admin page after login

### DIFF
--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -113,7 +113,9 @@ func (s *Server) renderTemplate(w http.ResponseWriter, r *http.Request, name str
 		// Given LoadTemplates structure: `template.New(templateName).ParseFiles(path, adminLayoutPath)`
 		// and `ExecuteTemplate(w, "layout", ...)`, "layout" must be a defined template name
 		// within the set, usually from adminLayoutPath.
-		return tmpl.ExecuteTemplate(w, "layout.html", wrappedData) // Assuming layout defines "layout.html"
+		// Execute the main template for the page (e.g., "admin/dashboard.html"),
+		// which should internally call the layout.
+		return tmpl.Execute(w, wrappedData)
 	}
 	// For non-admin templates, tmpl.Execute will execute the template named `templateName`
 	// which was used in `template.New(templateName)` during LoadTemplates.

--- a/internal/server/web/templates/admin/dashboard.html
+++ b/internal/server/web/templates/admin/dashboard.html
@@ -1,4 +1,4 @@
-{{ template "admin/layout.html" . }}
+{{ template "layout" . }}
 {{ define "content" }}
 <div class="dashboard">    
     <div class="stats-grid">

--- a/internal/server/web/templates/admin/feeds.html
+++ b/internal/server/web/templates/admin/feeds.html
@@ -1,4 +1,4 @@
-{{ template "admin/layout.html" . }}
+{{ template "layout" . }}
 {{ define "content" }}
 <div class="feeds-container">
 <div class="panel add-feed">

--- a/internal/server/web/templates/admin/settings.html
+++ b/internal/server/web/templates/admin/settings.html
@@ -1,4 +1,4 @@
-{{ template "admin/layout.html" . }}
+{{ template "layout" . }}
 {{ define "content" }}
 <div class="settings-container">
     <div class="panel">


### PR DESCRIPTION
This commit addresses an issue where admin pages (e.g., dashboard, settings, feeds) would appear blank after a successful login.

The primary cause was an incorrect template execution strategy in the `renderTemplate` function for admin pages. It was attempting to render a template named "layout.html" directly, whereas the admin layout file defines a template named "layout". Additionally, individual admin content pages were calling the layout template using the full path "admin/layout.html" instead of its defined name "layout".

Key changes include:

1.  Modified `renderTemplate` in `internal/server/auth_handlers.go`:
    - For admin paths, it now calls `tmpl.Execute(w, wrappedData)`. This executes the specific page template (e.g., "admin/dashboard.html"), which in turn is responsible for invoking the layout.

2.  Updated admin content page templates (`dashboard.html`, `feeds.html`, `settings.html`):
    - Changed the layout invocation from `{{ template "admin/layout.html" . }}` to `{{ template "layout" . }}` to correctly call the template defined in `admin/layout.html`.

These changes ensure the correct Go template execution flow for admin pages, allowing them to render their content within the shared admin layout as intended.