### PR TITLE
Fix: Correct admin page rendering and resolve 'incomplete template' e…

### DIFF
--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -112,10 +112,11 @@ func (s *Server) renderTemplate(w http.ResponseWriter, r *http.Request, name str
 		// or if the layout file was the primary file parsed in a specific way.
 		// Given LoadTemplates structure: `template.New(templateName).ParseFiles(path, adminLayoutPath)`
 		// and `ExecuteTemplate(w, "layout", ...)`, "layout" must be a defined template name
-		// within the set, usually from adminLayoutPath.
-		// Execute the main template for the page (e.g., "admin/dashboard.html"),
-		// which should internally call the layout.
-		return tmpl.Execute(w, wrappedData)
+		// within enlight.
+		// tmpl (s.templateCache[name]) should have "layout" (from admin/layout.html)
+		// and "content" (from e.g. admin/dashboard.html) defined within it.
+		// Executing "layout" will then pull in "content".
+		return tmpl.ExecuteTemplate(w, "layout", wrappedData)
 	}
 	// For non-admin templates, tmpl.Execute will execute the template named `templateName`
 	// which was used in `template.New(templateName)` during LoadTemplates.

--- a/internal/server/web/templates/admin/dashboard.html
+++ b/internal/server/web/templates/admin/dashboard.html
@@ -1,4 +1,3 @@
-{{ template "layout" . }}
 {{ define "content" }}
 <div class="dashboard">    
     <div class="stats-grid">

--- a/internal/server/web/templates/admin/feeds.html
+++ b/internal/server/web/templates/admin/feeds.html
@@ -1,4 +1,3 @@
-{{ template "layout" . }}
 {{ define "content" }}
 <div class="feeds-container">
 <div class="panel add-feed">

--- a/internal/server/web/templates/admin/settings.html
+++ b/internal/server/web/templates/admin/settings.html
@@ -1,4 +1,3 @@
-{{ template "layout" . }}
 {{ define "content" }}
 <div class="settings-container">
     <div class="panel">


### PR DESCRIPTION
…rror

This commit fixes an issue where admin pages would either show an 'Internal Server Error' page or a blank page due to incorrect template execution logic. The specific error ""template: "admin/dashboard.html" is an incomplete or empty template"" indicated that page-specific templates were being executed directly when they should have been rendered as part of a layout.

The fix involves two main changes:

1.  Modified `renderTemplate` in `internal/server/auth_handlers.go`:
    - For admin paths, the function now consistently executes the "layout" template (defined in `admin/layout.html`) using `tmpl.ExecuteTemplate(w, "layout", wrappedData)`. This "layout" template is responsible for including content from page-specific blocks.

2.  Updated admin content page templates (`admin/dashboard.html`, `admin/feeds.html`, `admin/settings.html`):
    - Removed the `{{ template "layout" . }}` directive from the top of these files.
    - These files now exclusively define blocks (e.g., `{{define "content"}}`, `{{define "styles"}}`), which are then rendered by the "layout" template.

This approach aligns with standard Go template practices for using layouts and content pages, ensuring that `s.templateCache[<admin_page_name>]` contains all necessary definitions (from both the page file and the layout file) and that rendering starts by executing the main layout.