### PR TITLE
feat: Add RSS feed generation

### DIFF
--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -1,0 +1,31 @@
+package rss
+
+import "encoding/xml"
+
+// RSS is the root element of an RSS feed.
+type RSS struct {
+	XMLName xml.Name `xml:"rss"`
+	Version string   `xml:"version,attr"`
+	Channel Channel  `xml:"channel"`
+}
+
+// Channel represents the channel element in an RSS feed.
+type Channel struct {
+	XMLName       xml.Name `xml:"channel"`
+	Title         string   `xml:"title"`
+	Link          string   `xml:"link"`
+	Description   string   `xml:"description"`
+	Language      string   `xml:"language,omitempty"`
+	LastBuildDate string   `xml:"lastBuildDate,omitempty"` // Should be in RFC1123Z format
+	Items         []Item   `xml:"item"`
+}
+
+// Item represents an item element in an RSS feed.
+type Item struct {
+	XMLName     xml.Name `xml:"item"`
+	Title       string   `xml:"title"`
+	Link        string   `xml:"link"`
+	Description string   `xml:"description,omitempty"` // Optional, can be a summary or full content
+	PubDate     string   `xml:"pubDate,omitempty"`     // Should be in RFC1123Z format
+	GUID        string   `xml:"guid,omitempty"`        // A unique identifier for the item, can be the link
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -229,6 +229,8 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("/admin/upload-favicon", s.requireAuth(s.imageHandler.HandleFaviconUpload))
 	mux.HandleFunc("/admin/upload-meta-image", s.requireAuth(s.imageHandler.HandleMetaImageUpload))
 
+	mux.HandleFunc("/rss.xml", s.handleRSS) // Added route for RSS feed
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			s.handle404(w, r)

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -20,9 +20,10 @@ const (
 type EntryView struct {
 	ID         int64  `json:"id"`
 	Title      string `json:"title"`
-	URL        string `json:"url"`
-	FaviconURL string `json:"faviconUrl"`
-	Date       string `json:"date"`
+	URL             string    `json:"url"`
+	FaviconURL      string    `json:"faviconUrl"`
+	Date            string    `json:"date"` // Formatted date for display
+	PublishedAtTime time.Time `json:"-"`    // Raw time for RSS, excluded from JSON
 }
 
 type IndexData struct {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -29,6 +29,7 @@
     {{ end }}
 
     <link rel="icon" type="image/x-icon" href="/static/images/favicon/{{ .Data.Settings.favicon_url }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ .Data.Title }} RSS Feed" href="/rss.xml">
     <style>
         body {
             font-family: 'Courier New', Courier, monospace;


### PR DESCRIPTION
This commit introduces an RSS 2.0 feed for the application.

The feed is available at `/rss.xml` and includes entries from the main page, using their titles, links, and publication dates.

Key changes:
- Defined RSS feed structures (RSS, Channel, Item) in `internal/rss/rss.go`.
- Added a new HTTP handler `handleRSS` in `internal/server/handlers.go` to fetch data and generate the XML feed.
- Ensured correct parsing and formatting of `pubDate` for each feed item using the original `published_at` timestamp.
- Registered the `/rss.xml` route in `internal/server/server.go`.
- Added an RSS auto-discovery link tag to the `<head>` of `web/templates/index.html`.
- Included unit tests for the `handleRSS` handler, mocking database interactions and validating the generated XML output.