### PR TITLE
fix: Improve RSS feed validity and add features

### DIFF
--- a/internal/rss/rss.go
+++ b/internal/rss/rss.go
@@ -6,7 +6,15 @@ import "encoding/xml"
 type RSS struct {
 	XMLName xml.Name `xml:"rss"`
 	Version string   `xml:"version,attr"`
+	AtomNS  string   `xml:"xmlns:atom,attr,omitempty"` // Atom namespace
 	Channel Channel  `xml:"channel"`
+}
+
+// AtomLink defines the structure for an atom:link element.
+type AtomLink struct {
+	Href string `xml:"href,attr"`
+	Rel  string `xml:"rel,attr"`
+	Type string `xml:"type,attr,omitempty"`
 }
 
 // Channel represents the channel element in an RSS feed.
@@ -17,6 +25,7 @@ type Channel struct {
 	Description   string   `xml:"description"`
 	Language      string   `xml:"language,omitempty"`
 	LastBuildDate string   `xml:"lastBuildDate,omitempty"` // Should be in RFC1123Z format
+	SelfLink      AtomLink `xml:"atom:link,omitempty"`     // Atom link for self-reference
 	Items         []Item   `xml:"item"`
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -980,122 +980,157 @@ func TestHandleAdmin_GET_Dashboard(t *testing.T) {
 }
 
 func TestHandleRSS(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-	defer db.Close()
-
 	logger := log.New(io.Discard, "", 0)
-	// Config can be minimal for this test as handleRSS doesn't directly use it beyond what's fetched from settings.
-	serverConfig := Config{}
+	serverConfig := Config{} // Minimal config
 
-	s := &Server{
-		db:     db,
-		logger: logger,
-		config: serverConfig,
-		// templateCache can be nil as handleRSS writes XML directly and doesn't use HTML templates for success path.
-		// csrf can be nil as handleRSS is not a CSRF-protected endpoint.
-		// Other services like feedService, auth, imageHandler are not used by handleRSS.
+	runTest := func(t *testing.T, name string, setupMocks func(mock sqlmock.Sqlmock), assertions func(rr *httptest.ResponseRecorder, rssFeed rss.RSS)) {
+		t.Run(name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual)) // Use QueryMatcherEqual for precise query matching
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer db.Close()
+
+			s := &Server{
+				db:     db,
+				logger: logger,
+				config: serverConfig,
+			}
+
+			setupMocks(mock)
+
+			req := httptest.NewRequest("GET", "/rss.xml", nil)
+			rr := httptest.NewRecorder()
+			s.handleRSS(rr, req)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v. Body: %s", status, http.StatusOK, rr.Body.String())
+			}
+
+			expectedContentType := "application/rss+xml; charset=utf-8"
+			if contentType := rr.Header().Get("Content-Type"); contentType != expectedContentType {
+				t.Errorf("handler returned wrong content type: got %v want %v", contentType, expectedContentType)
+			}
+
+			var rssFeed rss.RSS
+			if err := xml.Unmarshal(rr.Body.Bytes(), &rssFeed); err != nil {
+				t.Fatalf("Failed to unmarshal XML response: %v. Body: %s", err, rr.Body.String())
+			}
+
+			assertions(rr, rssFeed)
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("there were unfulfilled expectations: %s", err)
+			}
+		})
 	}
 
-	// Mock settings
-	settingsRows := sqlmock.NewRows([]string{"key", "value"}).
-		AddRow("site_title", "Test Site").
-		AddRow("site_url", "http://localhost:8080").
-		AddRow("meta_description", "Test Description").
-		AddRow("max_posts", "2") // Using 2 for simpler test data
+	// Test Case 1: Site URL is set
+	runTest(t, "SiteURLIsSet", func(mock sqlmock.Sqlmock) {
+		mockedSiteURL := "http://testhost.com"
+		settingsRows := sqlmock.NewRows([]string{"key", "value"}).
+			AddRow("site_title", "Test Site").
+			AddRow("site_url", mockedSiteURL).
+			AddRow("meta_description", "Test Description").
+			AddRow("max_posts", "1")
+		mock.ExpectQuery("SELECT key, value FROM settings").WillReturnRows(settingsRows)
 
-	mock.ExpectQuery("SELECT key, value FROM settings").WillReturnRows(settingsRows)
+		entryTimeStr := "2023-01-01 10:00:00"
+		entriesRows := sqlmock.NewRows([]string{"id", "title", "url", "favicon_url", "date"}).
+			AddRow(1, "Test Entry 1", mockedSiteURL+"/entry1", "/favicon.ico", entryTimeStr)
+		mock.ExpectQuery(`SELECT e.id, e.title, e.url, e.favicon_url, datetime(e.published_at) as date FROM entries e JOIN feeds f ON e.feed_id = f.id WHERE f.status != 'deleted' ORDER BY e.published_at DESC LIMIT ?`).
+			WithArgs(1).WillReturnRows(entriesRows)
 
-	// Mock entries
-	// published_at format from query: "YYYY-MM-DD HH:MM:SS"
-	entryTime1Str := "2023-01-01 10:00:00"
-	entryTime2Str := "2023-01-02 11:00:00"
+	}, func(rr *httptest.ResponseRecorder, rssFeed rss.RSS) {
+		mockedSiteURL := "http://testhost.com"
+		expectedAtomLinkHref := mockedSiteURL + "/rss.xml"
 
-	entryTime1, _ := time.Parse("2006-01-02 15:04:05", entryTime1Str)
-	entryTime2, _ := time.Parse("2006-01-02 15:04:05", entryTime2Str)
-
-	entriesRows := sqlmock.NewRows([]string{"id", "title", "url", "favicon_url", "date"}).
-		AddRow(1, "Test Entry 1", "http://localhost:8080/entry1", "/favicon.ico", entryTime1Str).
-		AddRow(2, "Test Entry 2", "http://localhost:8080/entry2", "/favicon.ico", entryTime2Str)
-
-	// The query in getRecentEntries uses `LIMIT ?`
-	mock.ExpectQuery(`SELECT e.id, e.title, e.url, e.favicon_url, datetime\(e.published_at\) as date FROM entries e JOIN feeds f ON e.feed_id = f.id WHERE f.status != 'deleted' ORDER BY e.published_at DESC LIMIT \?`).
-		WithArgs(2). // max_posts is 2
-		WillReturnRows(entriesRows)
-
-	req := httptest.NewRequest("GET", "/rss.xml", nil)
-	rr := httptest.NewRecorder()
-
-	s.handleRSS(rr, req)
-
-	// Assertions
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
-	}
-
-	expectedContentType := "application/rss+xml; charset=utf-8"
-	if contentType := rr.Header().Get("Content-Type"); contentType != expectedContentType {
-		t.Errorf("handler returned wrong content type: got %v want %v", contentType, expectedContentType)
-	}
-
-	var rssFeed rss.RSS
-	if err := xml.Unmarshal(rr.Body.Bytes(), &rssFeed); err != nil {
-		t.Fatalf("Failed to unmarshal XML response: %v. Body: %s", err, rr.Body.String())
-	}
-
-	if rssFeed.Version != "2.0" {
-		t.Errorf("RSS version: got %s, want %s", rssFeed.Version, "2.0")
-	}
-	if rssFeed.Channel.Title != "Test Site" {
-		t.Errorf("Channel title: got %s, want %s", rssFeed.Channel.Title, "Test Site")
-	}
-	if rssFeed.Channel.Link != "http://localhost:8080" {
-		t.Errorf("Channel link: got %s, want %s", rssFeed.Channel.Link, "http://localhost:8080")
-	}
-	if rssFeed.Channel.Description != "Test Description" {
-		t.Errorf("Channel description: got %s, want %s", rssFeed.Channel.Description, "Test Description")
-	}
-	if len(rssFeed.Channel.Items) != 2 {
-		t.Errorf("Number of items: got %d, want %d", len(rssFeed.Channel.Items), 2)
-	}
-
-	// Check items
-	if len(rssFeed.Channel.Items) == 2 {
-		item1 := rssFeed.Channel.Items[0]
-		if item1.Title != "Test Entry 1" {
-			t.Errorf("Item 1 title: got %s, want %s", item1.Title, "Test Entry 1")
+		if rssFeed.Channel.Link != mockedSiteURL {
+			t.Errorf("Channel link: got %s, want %s", rssFeed.Channel.Link, mockedSiteURL)
 		}
-		if item1.Link != "http://localhost:8080/entry1" {
-			t.Errorf("Item 1 link: got %s, want %s", item1.Link, "http://localhost:8080/entry1")
+		if rssFeed.AtomNS != "http://www.w3.org/2005/Atom" {
+			t.Errorf("AtomNS: got %s, want %s", rssFeed.AtomNS, "http://www.w3.org/2005/Atom")
 		}
-		// RFC1123Z format. time.Parse above gives local time. Format will convert to UTC if Z is specified.
-		// The test data is naive, so Format will assume local. To be robust, parse as UTC or ensure test runs in UTC.
-		// For simplicity, we'll compare with the local time's RFC1123Z representation.
-		// If server runs in UTC, then this would be entryTime1.In(time.UTC).Format(time.RFC1123Z)
-		// The `Format(time.RFC1123Z)` method on a `time.Time` object will correctly format it with a numeric timezone offset.
-		expectedPubDate1 := entryTime1.Format(time.RFC1123Z)
-		if item1.PubDate != expectedPubDate1 {
-			t.Errorf("Item 1 PubDate: got %s, want %s", item1.PubDate, expectedPubDate1)
+		if rssFeed.Channel.SelfLink.Href != expectedAtomLinkHref {
+			t.Errorf("SelfLink Href: got %s, want %s", rssFeed.Channel.SelfLink.Href, expectedAtomLinkHref)
 		}
+		if rssFeed.Channel.SelfLink.Rel != "self" {
+			t.Errorf("SelfLink Rel: got %s, want %s", rssFeed.Channel.SelfLink.Rel, "self")
+		}
+		if rssFeed.Channel.SelfLink.Type != "application/rss+xml" {
+			t.Errorf("SelfLink Type: got %s, want %s", rssFeed.Channel.SelfLink.Type, "application/rss+xml")
+		}
+		if rssFeed.Channel.Title != "Test Site" { // Basic check from original test
+			t.Errorf("Channel title: got %s, want %s", rssFeed.Channel.Title, "Test Site")
+		}
+		if len(rssFeed.Channel.Items) != 1 {
+			t.Errorf("Number of items: got %d, want %d", len(rssFeed.Channel.Items), 1)
+		}
+	})
 
-		item2 := rssFeed.Channel.Items[1]
-		if item2.Title != "Test Entry 2" {
-			t.Errorf("Item 2 title: got %s, want %s", item2.Title, "Test Entry 2")
-		}
-		if item2.Link != "http://localhost:8080/entry2" {
-			t.Errorf("Item 2 link: got %s, want %s", item2.Link, "http://localhost:8080/entry2")
-		}
-		expectedPubDate2 := entryTime2.Format(time.RFC1123Z)
-		if item2.PubDate != expectedPubDate2 {
-			t.Errorf("Item 2 PubDate: got %s, want %s", item2.PubDate, expectedPubDate2)
-		}
-	}
+	// Test Case 2: Site URL is missing (empty string)
+	runTest(t, "SiteURLIsMissing", func(mock sqlmock.Sqlmock) {
+		settingsRows := sqlmock.NewRows([]string{"key", "value"}).
+			AddRow("site_title", "Test Site No URL").
+			AddRow("site_url", ""). // Site URL is empty
+			AddRow("meta_description", "Description No URL").
+			AddRow("max_posts", "1")
+		mock.ExpectQuery("SELECT key, value FROM settings").WillReturnRows(settingsRows)
 
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expectations: %s", err)
-	}
+		entryTimeStr := "2023-01-03 10:00:00"
+		entriesRows := sqlmock.NewRows([]string{"id", "title", "url", "favicon_url", "date"}).
+			AddRow(3, "Entry No URL", "http://example.com/entry3", "/favicon.ico", entryTimeStr)
+		mock.ExpectQuery(`SELECT e.id, e.title, e.url, e.favicon_url, datetime(e.published_at) as date FROM entries e JOIN feeds f ON e.feed_id = f.id WHERE f.status != 'deleted' ORDER BY e.published_at DESC LIMIT ?`).
+			WithArgs(1).WillReturnRows(entriesRows)
+
+	}, func(rr *httptest.ResponseRecorder, rssFeed rss.RSS) {
+		if rssFeed.Channel.Link != "" {
+			t.Errorf("Channel link: got %s, want empty string", rssFeed.Channel.Link)
+		}
+		if rssFeed.AtomNS != "http://www.w3.org/2005/Atom" { // AtomNS should still be present
+			t.Errorf("AtomNS: got %s, want %s", rssFeed.AtomNS, "http://www.w3.org/2005/Atom")
+		}
+		if rssFeed.Channel.SelfLink.Href != "" { // Href should be empty due to omitempty and logic in handleRSS
+			t.Errorf("SelfLink Href: got %s, want empty string", rssFeed.Channel.SelfLink.Href)
+		}
+		// Rel and Type might be their zero values if Href is empty and the whole struct is omitted.
+		// If Href is empty, the link is considered invalid/omitted.
+		if rssFeed.Channel.SelfLink.Rel != "" && rssFeed.Channel.SelfLink.Href != "" {
+			t.Errorf("SelfLink Rel: got %s, want empty string if Href is empty", rssFeed.Channel.SelfLink.Rel)
+		}
+		if rssFeed.Channel.SelfLink.Type != "" && rssFeed.Channel.SelfLink.Href != "" {
+			t.Errorf("SelfLink Type: got %s, want empty string if Href is empty", rssFeed.Channel.SelfLink.Type)
+		}
+		if rssFeed.Channel.Title != "Test Site No URL" {
+			t.Errorf("Channel title: got %s, want %s", rssFeed.Channel.Title, "Test Site No URL")
+		}
+	})
+
+	// Test Case 3: Site URL is not present in settings at all (key missing)
+	runTest(t, "SiteURLKeyMissing", func(mock sqlmock.Sqlmock) {
+		settingsRows := sqlmock.NewRows([]string{"key", "value"}).
+			AddRow("site_title", "Test Site Key Missing").
+			// site_url key is not added to rows
+			AddRow("meta_description", "Description Key Missing").
+			AddRow("max_posts", "0") // No entries needed for this specific check
+		mock.ExpectQuery("SELECT key, value FROM settings").WillReturnRows(settingsRows)
+
+		// No entries expected if max_posts is 0
+		mock.ExpectQuery(`SELECT e.id, e.title, e.url, e.favicon_url, datetime(e.published_at) as date FROM entries e JOIN feeds f ON e.feed_id = f.id WHERE f.status != 'deleted' ORDER BY e.published_at DESC LIMIT ?`).
+			WithArgs(0).WillReturnRows(sqlmock.NewRows([]string{"id", "title", "url", "favicon_url", "date"}))
+
+
+	}, func(rr *httptest.ResponseRecorder, rssFeed rss.RSS) {
+		if rssFeed.Channel.Link != "" { // settings["site_url"] would be "" (zero value for string map access)
+			t.Errorf("Channel link: got %s, want empty string", rssFeed.Channel.Link)
+		}
+		if rssFeed.AtomNS != "http://www.w3.org/2005/Atom" {
+			t.Errorf("AtomNS: got %s, want %s", rssFeed.AtomNS, "http://www.w3.org/2005/Atom")
+		}
+		if rssFeed.Channel.SelfLink.Href != "" {
+			t.Errorf("SelfLink Href: got %s, want empty string", rssFeed.Channel.SelfLink.Href)
+		}
+	})
 }
 
 // S_runtime_Caller_SANDBOX_ENABLED_SORRY_CannotCallThis is a placeholder for runtime.Caller

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -229,7 +229,9 @@ func (s *Server) Routes() http.Handler {
 	mux.HandleFunc("/admin/upload-favicon", s.requireAuth(s.imageHandler.HandleFaviconUpload))
 	mux.HandleFunc("/admin/upload-meta-image", s.requireAuth(s.imageHandler.HandleMetaImageUpload))
 
-	mux.HandleFunc("/rss.xml", s.handleRSS) // Added route for RSS feed
+	mux.HandleFunc("/rss.xml", s.handleRSS)
+	mux.HandleFunc("/rss", s.handleRSS)     // New route
+	mux.HandleFunc("/feed", s.handleRSS)    // New route
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -80,6 +80,7 @@ type Settings struct {
 	Timezone          string `json:"timezone"`
 	MetaDescription   string `json:"metaDescription"`
 	MetaImageURL      string `json:"metaImageURL"`
+	SiteURL           string `json:"site_url"` // Added for site_url setting
 }
 
 type Feed struct {

--- a/web/templates/admin/settings.html
+++ b/web/templates/admin/settings.html
@@ -8,6 +8,11 @@
                 <input type="text" id="siteTitle" name="siteTitle" value="{{ index .Data.Settings "site_title" }}" required>
             </div>
             <div class="setting-group">
+                <label for="site_url">SITE URL</label>
+                <input type="url" id="site_url" name="site_url" value="{{ index .Data.Settings "site_url" }}" placeholder="e.g., https://yourdomain.com" required>
+                <div class="help-text">Important for RSS feed and canonical links. Should be the full public URL of your site.</div>
+            </div>
+            <div class="setting-group">
                 <label for="maxPosts">MAXIMUM POSTS</label>
                 <input type="number" id="maxPosts" name="maxPosts" value="{{ index .Data.Settings "max_posts" }}" min="1" required>
             </div>
@@ -690,7 +695,8 @@ textarea:focus {
                         timezone: document.getElementById('timezone').value,
                         trackingCode: document.getElementById('trackingCode').value,
                         metaDescription: document.getElementById('metaDescription').value,
-                        metaImageURL: metaImageURL
+                        metaImageURL: metaImageURL,
+                        site_url: document.getElementById('site_url').value
                     };
         
                     const response = await csrf.fetch('/admin/settings', {


### PR DESCRIPTION
This commit addresses several issues with the RSS feed to improve its validity and adds new features based on your feedback.

Key changes:

1.  **Exposed `site_url` in Admin Settings:**
    - Added a "Site URL" field to the admin settings page (`web/templates/admin/settings.html`).
    - Updated `internal/server/handlers.go` (`updateSettings`) and `internal/server/types.go` (`Settings` struct) to support saving this new setting.
    - This is crucial for generating a valid `link` in the RSS channel.

2.  **Used `site_url` for Channel Link:**
    - The `handleRSS` function in `internal/server/handlers.go` now uses the `site_url` setting for the `<channel><link>` element.
    - A warning is logged if `site_url` is not configured.

3.  **Added `atom:link` for Self-Reference:**
    - Modified `internal/rss/rss.go` to include `AtomNS` in the `RSS` struct and `SelfLink AtomLink` in the `Channel` struct.
    - `handleRSS` now populates this link (e.g., `<atom:link href="[site_url]/rss.xml" rel="self" type="application/rss+xml" />`) if `site_url` is set. This improves feed discoverability and interoperability.

4.  **Added Additional RSS Routes:**
    - The RSS feed is now also available at `/rss` and `/feed` in addition to `/rss.xml`. Routes were added in `internal/server/server.go`.

5.  **Backup/Restore Functionality:**
    - Verified that the new `site_url` setting is automatically included in the existing backup and restore functionality as it operates on all key-value pairs in the `settings` table.

6.  **Updated Unit Tests:**
    - `TestHandleRSS` in `internal/server/handlers_test.go` was significantly updated to cover: - Correct generation of channel link and `atom:link` when `site_url` is set. - Correct handling (empty channel link, omitted `atom:link`) when `site_url` is missing or empty. - Verification of the Atom namespace.

These changes ensure the RSS feed is more compliant with standards, more discoverable, and robustly configured.