### PR TITLE
Fix: Remove JS-based favicon loading to prevent visible pop-in

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -258,41 +258,6 @@
             window.open(url, '_blank');
             return false; // Prevent default link behavior
         }
-
-        // Optimize favicon loading on desktop
-        document.addEventListener('DOMContentLoaded', function() {
-            // Only apply optimizations on desktop (viewport wider than 768px)
-            if (window.innerWidth > 768) {
-                const favicons = document.querySelectorAll('.favicon');
-                
-                // Use Intersection Observer for lazy loading beyond the fold
-                if ('IntersectionObserver' in window) {
-                    const observer = new IntersectionObserver((entries) => {
-                        entries.forEach(entry => {
-                            if (entry.isIntersecting) {
-                                const img = entry.target;
-                                if (img.dataset.src) {
-                                    img.src = img.dataset.src;
-                                    img.removeAttribute('data-src');
-                                    observer.unobserve(img);
-                                }
-                            }
-                        });
-                    }, {
-                        rootMargin: '50px 0px'
-                    });
-
-                    // Only lazy load favicons beyond the first 15 entries
-                    favicons.forEach((img, index) => {
-                        if (index >= 15) {
-                            img.dataset.src = img.src;
-                            img.src = '/static/favicons/default.ico';
-                            observer.observe(img);
-                        }
-                    });
-                }
-            }
-        });
     </script>
 
     {{ if .Data.TrackingCode }}


### PR DESCRIPTION
The previous JavaScript-based favicon optimization on desktop browsers caused a "visibly populating" effect for favicons. This occurred because the script would set a default favicon source and then swap to the actual favicon source upon IntersectionObserver trigger.

This was unnecessary as:
1. Favicons are already cached locally by the backend and served from your application's own domain (e.g., /static/favicons/hash.ico).
2. The `<img>` tags for favicons already utilize `loading="lazy"`, which is the standard mechanism for deferring offscreen image loading.
3. Critical above-the-fold favicons (first 10) are already preloaded using `<link rel="preload">`.

This commit removes the custom JavaScript `DOMContentLoaded` listener responsible for this behavior in `web/templates/index.html`. Your page now relies solely on `loading="lazy"` for lazy-loading favicons and `preload` for critical ones, simplifying the logic and eliminating the visual pop-in effect. This also ensures consistent loading behavior between desktop and mobile.