### PR TITLE
Emergency fix: Add missing CSRF token and fix body text display logic

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -98,8 +98,10 @@ func (s *Server) getRecentEntriesWithSettings(ctx context.Context, limit int, se
 		}
 
 		// Set body text and feed title
-		if content.Valid && settings != nil && settings["show_body_text"] == "true" {
-			e.BodyText = content.String
+		if content.Valid && settings != nil {
+			if showBodyText, ok := settings["show_body_text"]; ok && showBodyText == "true" {
+				e.BodyText = content.String
+			}
 		}
 		if feedTitle.Valid {
 			e.FeedTitle = feedTitle.String

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -98,7 +98,7 @@ func (s *Server) getRecentEntriesWithSettings(ctx context.Context, limit int, se
 		}
 
 		// Set body text and feed title
-		if content.Valid {
+		if content.Valid && settings != nil && settings["show_body_text"] == "true" {
 			e.BodyText = content.String
 		}
 		if feedTitle.Valid {

--- a/internal/server/web/templates/admin/settings.html
+++ b/internal/server/web/templates/admin/settings.html
@@ -1,7 +1,9 @@
 {{ define "content" }}
 <div class="settings-container">
     <div class="panel">
-        <form id="settingsForm">            <div class="setting-group">
+        <form id="settingsForm">
+            <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
+            <div class="setting-group">
                 <label for="siteTitle">SITE TITLE</label>
                 <input type="text" id="siteTitle" name="siteTitle" value="{{ index .Data.Settings "site_title" }}" required>
             </div>


### PR DESCRIPTION
- Fixed settings page form missing CSRF token hidden input field
- Fixed body text displaying even when show_body_text setting is false
- Updated template to check show_body_text setting before displaying content
- Updated handler to only set BodyText when show_body_text is enabled