### PR TITLE
Fix feed titles disappearing when fetch returns empty title

### DIFF
--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -37,6 +37,16 @@ func NewFetcher(db *sql.DB, logger *log.Logger, faviconSvc *favicon.Service) *Fe
 	}
 }
 
+// formattedTimestamp returns the current time formatted for database storage
+func (f *Fetcher) formattedTimestamp() string {
+	return time.Now().UTC().Format("2006-01-02 15:04:05")
+}
+
+// formatTimestamp formats a given time for database storage
+func (f *Fetcher) formatTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04:05")
+}
+
 type cacheEntry struct {
 	lastModified string
 	etag         string
@@ -238,14 +248,14 @@ func (f *Fetcher) saveFeedEntries(ctx context.Context, result FetchResult) error
 		if result.FeedTitle != "" {
 			_, err := f.db.ExecContext(ctx,
 				"UPDATE feeds SET last_fetched = DATETIME(?), title = ? WHERE id = ?",
-				time.Now().UTC().Format("2006-01-02 15:04:05"), result.FeedTitle, result.Feed.ID,
+				f.formattedTimestamp(), result.FeedTitle, result.Feed.ID,
 			)
 			return err
 		} else {
 			// If the title is empty, only update the last_fetched time
 			_, err := f.db.ExecContext(ctx,
 				"UPDATE feeds SET last_fetched = DATETIME(?) WHERE id = ?",
-				time.Now().UTC().Format("2006-01-02 15:04:05"), result.Feed.ID,
+				f.formattedTimestamp(), result.Feed.ID,
 			)
 			return err
 		}
@@ -261,13 +271,13 @@ func (f *Fetcher) saveFeedEntries(ctx context.Context, result FetchResult) error
 	if result.FeedTitle != "" {
 		_, err = tx.ExecContext(ctx,
 			"UPDATE feeds SET last_fetched = DATETIME(?), title = ? WHERE id = ?",
-			time.Now().UTC().Format("2006-01-02 15:04:05"), result.FeedTitle, result.Feed.ID,
+			f.formattedTimestamp(), result.FeedTitle, result.Feed.ID,
 		)
 	} else {
 		// If the title is empty, only update the last_fetched time
 		_, err = tx.ExecContext(ctx,
 			"UPDATE feeds SET last_fetched = DATETIME(?) WHERE id = ?",
-			time.Now().UTC().Format("2006-01-02 15:04:05"), result.Feed.ID,
+			f.formattedTimestamp(), result.Feed.ID,
 		)
 	}
 	if err != nil {
@@ -300,7 +310,7 @@ func (f *Fetcher) saveFeedEntries(ctx context.Context, result FetchResult) error
 			entry.URL,
 			entry.Content,
 			entry.GUID,
-			entry.PublishedAt.UTC().Format("2006-01-02 15:04:05"),
+			f.formatTimestamp(entry.PublishedAt),
 			entry.FaviconURL,
 		)
 		if err != nil {


### PR DESCRIPTION
- Prevent overwriting valid feed titles with empty strings during updates
- Only update feed title if new title is non-empty, otherwise preserve existing title
- Update last_fetched timestamp regardless of title availability
- Fixes issue where temporary network errors or malformed feeds could cause titles to disappear
- Both transaction and non-transaction code paths are now protected

Fixes #59