### PR TITLE
Fix GitHub Actions build failures

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,11 +59,7 @@ jobs:
         go-version: '1.22.4'
 
     - name: Install dependencies
-      run: |
-        go get github.com/mattn/go-sqlite3@v1.14.24
-        go get github.com/mmcdole/gofeed@v1.3.0
-        go get golang.org/x/crypto@v0.28.0
-        go get golang.org/x/net@v0.30.0
+      run: go mod download
 
     - name: Create Directories and Install UPX (Linux) 
       if: runner.os == 'Linux'
@@ -71,6 +67,7 @@ jobs:
         mkdir -p data
         mkdir -p web/static/favicons
         mkdir -p web/static/images
+        mkdir -p web/templates/admin
         sudo apt-get update && sudo apt-get install -y upx-ucl
       shell: bash
 
@@ -80,6 +77,7 @@ jobs:
         New-Item -ItemType Directory -Force -Path data
         New-Item -ItemType Directory -Force -Path web\static\favicons
         New-Item -ItemType Directory -Force -Path web\static\images
+        New-Item -ItemType Directory -Force -Path web\templates\admin
       shell: powershell
 
     - name: Setup MSYS2 (Windows)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -157,7 +157,7 @@ func TestSession_IsExpired(t *testing.T) {
 		},
 		{
 			name:      "session expiring in a moment",
-			session:   Session{ExpiresAt: now.Add(1 * time.Nanosecond)},
+			session:   Session{ExpiresAt: now.Add(1 * time.Millisecond)},
 			isExpired: false,
 		},
 	}


### PR DESCRIPTION
This commit fixes several issues that caused the GitHub Actions build to fail, while it was working locally.

- The dependency installation in the workflow is changed from multiple `go get` commands to a single `go mod download`. This is the modern, idiomatic way to handle Go dependencies and ensures that the CI build uses the exact versions from `go.mod`.

- The workflow is updated to create the `web/templates/admin` directory for both Linux and Windows builds. This directory is required at compile time by the `//go:embed` directive in `internal/server/server.go`, and its absence was causing the build to fail in the clean CI environment.

- A flaky test in `internal/auth/auth_test.go` (`TestSession_IsExpired`) is fixed by increasing a time delta from 1 nanosecond to 1 millisecond. This makes the test more robust against timing fluctuations on the CI runners.